### PR TITLE
fix: add owl to prefixes

### DIFF
--- a/__tests__/Conformance-test.js
+++ b/__tests__/Conformance-test.js
@@ -34,6 +34,7 @@ describe('Testing each extended conformance file', () => {
     expect(res).toBeRdfIsomorphic((new N3.Parser()).parse(ttl))
     expect(res.prefixes).toEqual({
       rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      owl: 'http://www.w3.org/2002/07/owl#',
       rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
       sh: 'http://www.w3.org/ns/shacl#',
       xsd: 'http://www.w3.org/2001/XMLSchema#',

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,8 @@ class Parser {
       rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
       rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
       sh: 'http://www.w3.org/ns/shacl#',
-      xsd: 'http://www.w3.org/2001/XMLSchema#'
+      xsd: 'http://www.w3.org/2001/XMLSchema#',
+      owl: 'http://www.w3.org/2002/07/owl#'
     }
     this._parser.Parser.currentNodeShape = undefined;
     this._parser.Parser.currentPropertyNode = undefined;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "owl" namespace, enabling recognition of OWL-prefixed terms in parsed RDF data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->