### PR TITLE
chore: add node 22 to CI

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded test coverage to include Node.js version 22.x in the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->