### PR TITLE
fix: raise a parse error on unrecognized characters

### DIFF
--- a/__tests__/Conformance-test.js
+++ b/__tests__/Conformance-test.js
@@ -47,6 +47,17 @@ describe('Testing each extended conformance file', () => {
   });
 });
 
+describe('Testing unrecognized characters', () => {
+  it('should throw rather than silently discarding characters the lexer cannot match', () => {
+    expect(() => parse(`
+    PREFIX ex: <http://example.org/>
+
+    shape ex:TestShape ~ {
+    }
+    `)).toThrowError();
+  });
+});
+
 describe('Testing relative IRIs', () => {
   it('should use the provided baseIRI to resolve relative IRIs', () => {
     expect(parse(`

--- a/lib/shaclc.jison
+++ b/lib/shaclc.jison
@@ -249,6 +249,12 @@ PARAM                   'deactivated' | 'severity' | 'message' | 'class' | 'data
 "%"                     return '%'
 "a"                     return 'a'
 
+// Catch-all for characters no other rule matches. Without this, the flex
+// option makes jison-lex echo unmatched characters to stdout and silently
+// drop them, so invalid input could "successfully" parse to incorrect quads.
+// INVALID is not a token in the grammar, so the parser raises a parse error.
+.                       return 'INVALID'
+
 <<EOF>>                 return 'EOF'
 
 /lex


### PR DESCRIPTION
## Problem

The lexer is generated with `%options flex`, and in that mode jison-lex appends a default catch-all rule whose action is literally `console.log(yytext)` — any character no rule matches is **echoed to stdout and silently discarded**. Invalid input can therefore "successfully" parse while producing incorrect quads:

```js
parse('PREFIX ex: <http://example.org/>\nshape ex:TestShape ~ {\n}')
// prints "~" to stdout, returns quads as if the ~ were never there
```

This is also the mechanism that turned the underscore lexing bug (#192) into silent IRI truncation rather than a loud failure.

## Fix

Add an explicit catch-all lexer rule that returns an `INVALID` token. The grammar has no such terminal, so the parser raises its standard `Parse error on line N` pointing at the offending character. Longest-match (flex) semantics are unaffected for every real token, and on equal-length matches jison keeps the first rule, so all existing single-character tokens still win over the catch-all.

Includes a regression test; all 59 tests pass.

Review timing: prepared with Claude; @jeswr will personally review before it progresses — expect active review Wed-Fri.