### PR TITLE
fix: accept '=' inside IRIREF

### DIFF
--- a/__tests__/valid/iri-with-equals.shaclc
+++ b/__tests__/valid/iri-with-equals.shaclc
@@ -1,0 +1,4 @@
+BASE <http://example.org/iri-with-equals>
+
+shape <http://example.org/shape?version=1> -> <http://example.org/Class?a=b> {
+}

--- a/__tests__/valid/iri-with-equals.ttl
+++ b/__tests__/valid/iri-with-equals.ttl
@@ -1,0 +1,13 @@
+@base <http://example.org/iri-with-equals> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+<http://example.org/iri-with-equals>
+	a owl:Ontology ;
+.
+
+<http://example.org/shape?version=1>
+	a sh:NodeShape ;
+	sh:targetClass <http://example.org/Class?a=b> ;
+.

--- a/lib/shaclc.jison
+++ b/lib/shaclc.jison
@@ -151,7 +151,9 @@
 PASS                    [ \t\r\n]+ -> skip
 COMMENT                 '#' ~[\r\n]* -> skip
 
-IRIREF                  '<' (~[^=<>\"\{\}\|\^`\\\u0000-\u0020] | {UCHAR})* '>'
+// [^...] rather than the previous ~[^=...]: the ANTLR-style negation (~) is not
+// jison-lex syntax (it was silently dropped), and '=' is a legal IRI character
+IRIREF                  '<' ([^<>\"\{\}\|\^`\\\u0000-\u0020] | {UCHAR})* '>'
 PNAME_NS                {PN_PREFIX}? ':'
 PNAME_LN                {PNAME_NS} {PN_LOCAL}
 ATPNAME_NS              '@' {PN_PREFIX}? ':'


### PR DESCRIPTION
## Problem

The `IRIREF` lexer macro was transcribed from the spec's ANTLR grammar as `~[^=<>...]`. Two problems compound here:

- `~` (ANTLR negation) is not jison-lex syntax and is silently dropped, so the negated class `[^=...]` is used as-is;
- `=` therefore ends up excluded, even though the Turtle/SHACL-C `IRIREF` production allows it.

Any IRI containing `=` fails to lex, and because of the flex echo behaviour (#193) the failure surfaces as a confusing downstream error:

```js
parse('BASE <http://example.org/b>\nshape <http://example.org/s?x=1> {\n}')
// throws: Unknown prefix: http
```

## Fix

Rewrite the macro as a plain negated character class matching the spec production (`'<' ([^<>\"{}|^\`\\\u0000-\u0020] | UCHAR)* '>'`), i.e. drop the stray `~` and the erroneous `=`. Adds a conformance fixture pair with `=` in both the shape IRI and target class IRI.

All 59 tests pass.

Review timing: prepared with Claude; @jeswr will personally review before it progresses — expect active review Wed-Fri.