### PR TITLE
perf: merge alternated character classes in lexer macros (~3x parse throughput)

### DIFF
--- a/lib/shaclc.jison
+++ b/lib/shaclc.jison
@@ -169,14 +169,14 @@ STRING_LITERAL_LONG2    "\"\"\""(?:(?:"\""|'""')?(?:[^\"\\]|{ECHAR}))*'"""'
 UCHAR                   '\\u' {HEX} {HEX} {HEX} {HEX} | '\\U' {HEX} {HEX} {HEX} {HEX} {HEX} {HEX} {HEX} {HEX}
 ECHAR                   '\\' [tbnrf\\\"\']
 WS                      [\u0020\u0009\u000D\u000A]
-PN_CHARS_BASE           [A-Z] | [a-z] | [\u00C0-\u00D6] | [\u00D8-\u00F6] | [\u00F8-\u02FF] | [\u0370-\u037D] | [\u037F-\u1FFF] | [\u200C-\u200D] | [\u2070-\u218F] | [\u2C00-\u2FEF] | [\u3001-\uD7FF] | [\uF900-\uFDCF] | [\uFDF0-\uFFFD]
+PN_CHARS_BASE           [A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]
 PN_CHARS_U              {PN_CHARS_BASE} | '_'
-PN_CHARS                {PN_CHARS_U} | '-' | [0-9] | [\u00B7] | [\u0300-\u036F] | [\u203F-\u2040]
+PN_CHARS                {PN_CHARS_U} | [\-0-9\u00B7\u0300-\u036F\u203F-\u2040]
 PN_PREFIX               {PN_CHARS_BASE} (({PN_CHARS} | '.')* {PN_CHARS})?
 PN_LOCAL                ({PN_CHARS_U} | ':' | [0-9] | {PLX}) (({PN_CHARS} | '.' | ':' | {PLX})* ({PN_CHARS} | ':' | {PLX}))?
 PLX                     {PERCENT} | {PN_LOCAL_ESC}
 PERCENT                 '%' {HEX} {HEX}
-HEX                     [0-9] | [A-F] | [a-f]
+HEX                     [0-9A-Fa-f]
 PN_LOCAL_ESC            '\\' ('_' | '~' | '.' | '-' | '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%')
 
 NODEKIND                'BlankNode' | 'IRI' | 'Literal' | 'BlankNodeOrIRI' | 'BlankNodeOrLiteral' | 'IRIOrLiteral'


### PR DESCRIPTION
## Rationale

Profiling `parse()` with `--cpu-prof` shows >50% of self time inside the generated `PNAME_NS` / `PNAME_LN` regexes. Two effects compound:

- the `PN_CHARS_BASE`, `PN_CHARS` and `HEX` macros are written as alternations of one-element character classes (`[A-Z] | [a-z] | [\u00C0-\u00D6] | ...`), mirroring the spec grammar's presentation, so the compiled regexes are deeply nested alternations evaluated per character;
- `%options flex` makes jison-lex run **every** rule's regex against the input for **every** token (longest-match), so these two regexes are executed at each token position.

Collapsing each alternation into a single character class (`[A-Za-z\u00C0-\u00D6...]`) is semantically identical — same code points, same macro structure — and lets the regex engine use a simple class-membership test.

## Numbers (this box: 2 shared cores, noisy — treat as indicative)

Synthetic 66 KB / 7,501-quad document (300 shapes x 5 property constraints), 20 iterations, back-to-back runs of the same benchmark script:

| | median | min | quads/s |
|---|---|---|---|
| main | 335.4 ms | 318.7 ms | ~22K |
| this PR | 104.5 ms | 99.9 ms | ~72K |

~3.2x end-to-end parse throughput. All 58 conformance tests pass (they compare output isomorphism against N3-parsed Turtle, so token semantics are well covered).

Further (not in this PR, higher risk): dropping `%options flex` in favour of first-match with reordered rules would avoid running all ~50 rules per token; and the remaining ~10% in `IRIREF` could benefit from the same treatment via its `UCHAR`/`HEX` expansion (already partly covered here).

Refs profiling notes in the triage issue.

Review timing: prepared with Claude; @jeswr will personally review before it progresses — expect active review Wed-Fri.