### PR TITLE
fix: do not leak a global 'head' variable from addList

### DIFF
--- a/__tests__/Conformance-test.js
+++ b/__tests__/Conformance-test.js
@@ -47,6 +47,19 @@ describe('Testing each extended conformance file', () => {
   });
 });
 
+describe('Testing global scope hygiene', () => {
+  it('should not leak a global "head" variable when emitting RDF lists', () => {
+    parse(`
+    PREFIX ex: <http://example.org/test#>
+
+    shape ex:TestShape {
+      ex:property in=[ex:Instance1 true "string" 42] .
+    }
+    `);
+    expect(globalThis.head).toBeUndefined();
+  });
+});
+
 describe('Testing relative IRIs', () => {
   it('should use the provided baseIRI to resolve relative IRIs', () => {
     expect(parse(`

--- a/lib/shaclc.jison
+++ b/lib/shaclc.jison
@@ -51,6 +51,7 @@
         return Parser.factory.namedNode(RDF_NIL)
       }
 
+      let head;
       const list = head = blank();
 
       if (l === 0) {


### PR DESCRIPTION
## Problem

`addList` in the grammar prologue assigns to an undeclared `head` identifier:

```js
const list = head = blank();
```

Every parse that emits an RDF list (`in=[...]`, path sequences, `sh:or` lists, ...) therefore sets `globalThis.head` to a term object. Besides the global-scope pollution, this is a latent breakage: if the generated parser is ever evaluated under strict mode (e.g. bundled as an ES module), the assignment throws a `ReferenceError`.

## Fix

Declare `head` with `let` in function scope. Includes a regression test asserting `globalThis.head` stays undefined after parsing a document with a list.

All 59 tests pass.

Review timing: prepared with Claude; @jeswr will personally review before it progresses — expect active review Wed-Fri.