### PR TITLE
fix: strict-mode leak — %-escape and trailing-turtle bypass extendedSyntax:false

### DIFF
--- a/__tests__/extended/propertyEscapeOnly.shaclc
+++ b/__tests__/extended/propertyEscapeOnly.shaclc
@@ -1,0 +1,11 @@
+BASE <http://example.org/class>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property ex:TestClass % 
+		ex:myPropertyEscape 1, [
+			ex:test ex:test2
+		]
+	% .
+}

--- a/__tests__/extended/propertyEscapeOnly.ttl
+++ b/__tests__/extended/propertyEscapeOnly.ttl
@@ -1,0 +1,22 @@
+@base <http://example.org/class> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:class ex:TestClass ;
+		ex:myPropertyEscape 1, [
+			ex:test ex:test2
+		]
+	] ;
+.

--- a/__tests__/extended/trailingTurtle.shaclc
+++ b/__tests__/extended/trailingTurtle.shaclc
@@ -1,0 +1,9 @@
+BASE <http://example.org/class>
+
+PREFIX ex: <http://example.org/test#>
+
+shape ex:TestShape {
+	ex:property ex:TestClass .
+}
+
+ex:extra ex:predicate ex:object .

--- a/__tests__/extended/trailingTurtle.ttl
+++ b/__tests__/extended/trailingTurtle.ttl
@@ -1,0 +1,21 @@
+@base <http://example.org/class> .
+@prefix ex: <http://example.org/test#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<>
+	a owl:Ontology ;
+.
+
+ex:TestShape
+	a sh:NodeShape ;
+	sh:property [
+		sh:path ex:property ;
+		sh:class ex:TestClass ;
+	] ;
+.
+
+ex:extra ex:predicate ex:object .

--- a/lib/shaclc.jison
+++ b/lib/shaclc.jison
@@ -344,7 +344,7 @@ RP                  : "%"
                     }
                     ;
 
-pcSection           : LP turtleAnnotation2 RP
+pcSection           : LP turtleAnnotation2 RP -> ensureExtended()
                     ;
 
 iriHead             : iri
@@ -353,7 +353,7 @@ iriHead             : iri
                     }
                     ;
 
-ttlStatement        : iriHead turtleAnnotation2 "." 
+ttlStatement        : iriHead turtleAnnotation2 "." -> ensureExtended()
                     ;
 
 ttlSection          : ttlStatement*


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated contribution from the sparq project (epic `sq-tonhr`, bead `sq-tonhr.5`; design record `research/shacl-compact-and-shuttle-parsers-2026-07.md` in jeswr/sparq).

## The leak

This parser supports four extended-syntax constructs beyond the [W3C SHACL Compact Syntax CG spec](https://w3c.github.io/shacl/shacl-compact-syntax/):

1. the turtle-style `;` node-shape annotation (`turtleAnnotation` production)
2. the `a` keyword as shorthand for `rdf:type` (the `'a'` alternative of the `iri` production)
3. `% ... %` property-value escapes (`pcSection` production)
4. trailing turtle statements after the shape declarations (`ttlStatement` / `ttlSection` productions)

All four are documented in the README as opt-in, gated behind `parse(str, { extendedSyntax: true })` — strict mode (the default, `extendedSyntax` omitted or `false`) is supposed to reject all four.

Only (1) and (2) were actually enforced, via `ensureExtended()` calls in `lib/shaclc.jison` on the `turtleAnnotation` and `'a'`-as-`iri` productions. The `pcSection` and `ttlStatement` productions had **no such guard**, so a document using *only* a `% ... %` escape, or *only* a trailing turtle statement, parsed successfully even with `extendedSyntax` left at its strict default:

```js
const { Parser } = require('shaclc-parse');

(new Parser()).parse(`
PREFIX ex: <http://example.org/test#>
shape ex:TestShape {
	ex:property ex:TestClass %
		ex:myPropertyEscape 1
	% .
}
`); // does NOT throw today, even though extendedSyntax defaults to false
```

The existing extended-conformance fixtures for the `%`-escape (`__tests__/extended/propertyEscape*.shaclc`) all *also* use the `;` annotation on the same shape, so the generic "parsing without `extendedSyntax` throws" assertion in `Conformance-test.js` passed for the wrong reason — the `;` guard fired first — and masked the fact that the escape itself was never checked.

## The fix

Add `-> ensureExtended()` to the `pcSection` and `ttlStatement` productions in `lib/shaclc.jison`, mirroring the exact guard style already used for `turtleAnnotation`/`a`. `lib/ShaclcParser.js` is regenerated from source via `npm run build` (the repo's normal build step) — not hand-edited.

## Tests

Two new isolated regression fixtures under `__tests__/extended/`, each exercising *only* the previously-unguarded construct (no `;`, no `a`):

- `propertyEscapeOnly.{shaclc,ttl}`
- `trailingTurtle.{shaclc,ttl}`

These plug into the existing parameterized loop in `Conformance-test.js`, which already asserts, per fixture: (a) the document parses to the RDF-isomorphic quad set under `extendedSyntax: true` — non-vacuous, confirming the accepted output is unchanged from before this fix — (b) the emitted prefixes match, and (c) parsing the same document with `extendedSyntax` at its default now throws.

Confirmed both new tests **fail** against the pre-fix grammar (leak reproduced) and **pass** after adding the two `ensureExtended()` guards. Full suite: 60/60 passing (58 pre-existing + 2 new), `npm run build` clean (no new SLR conflicts).

I also checked the fourth construct — the `[ ... ]` blank-node turtle-annotation form used inside a `;`/`%` block — but it is only reachable through the already-guarded `turtleAnnotation` or the now-guarded `pcSection` entry points, so it isn't an independent leak.

## Open question for the maintainer

Please confirm strict mode **should** reject `% ... %` escapes and trailing turtle statements (i.e. this is a bug fix, not a compat surface some consumer relies on). The README documents both as part of the same opt-in "Extended SHACL Compact Syntax" section as the two constructs that already throw, so I believe this is the intended behaviour — but if the old permissive behaviour was intentional, let me know and I'll close this out.

No auto-merge set — please review when convenient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for extended SHACLC syntax in property constraints and trailing Turtle statements.
  - Extended parsing now recognizes escaped property paths and additional Turtle content.

- **Bug Fixes**
  - Invalid use of extended syntax is rejected when extended parsing is disabled, providing clearer and more consistent validation.

- **Tests**
  - Added coverage for property escaping, SHACL property constraints, and trailing Turtle statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->